### PR TITLE
Update Fortuna implementation

### DIFF
--- a/Source/CryptoPP/Fortuna.h
+++ b/Source/CryptoPP/Fortuna.h
@@ -8,6 +8,7 @@
 #include "aes.h"
 #include "sha.h"
 #include "sha3.h"
+#include "dhash.h"
 #include "hrtimer.h"
 #include "misc.h"
 #include "config.h"
@@ -80,7 +81,7 @@ public:
 	Fortuna():Fortuna_Base(){ Initialize(); }
 private:
 	POOL_HASH m_PoolHashes[NUM_POOLS];
-	HashTransformation* GetPoolHash(byte i) {if(i>=NUM_POOLS){throw(InvalidArgument("can not access a Fortuna-Pool beyond 32!"));}return m_PoolHashes[i];}
+	HashTransformation* GetPoolHash(byte i) {if(i>=NUM_POOLS){throw(InvalidArgument("can not access a Fortuna-Pool beyond 32!"));}return &m_PoolHashes[i];}
 	HashTransformation* GetNewReseedHash() {return new RESEED_HASH();}
 	const typename CIPHER::Encryption m_InfoCipher;
 	BlockCipher* GetNewCipher() {return new typename CIPHER::Encryption();}
@@ -88,7 +89,7 @@ private:
 };
 
 // the original Fortuna as specified by Schneier, Fergueson and Kohno
-typedef Fortuna<AES,SHA256> OriginalFortuna;
+typedef Fortuna<AES,DoubledHash<SHA256> > OriginalFortuna;
 
 //! autoseeded version of Fortuna, isn't located in osrng.h because it's much more complex than implementations there
 class CRYPTOPP_NO_VTABLE AutoSeededFortuna_Base : public Fortuna_Base
@@ -154,7 +155,7 @@ public:
 	// create a new seed file after you've used the old one
 	virtual void ReadSeedFile(const byte* input,size_t length) {GetSingleton()->ReadSeedFile(input,length);}
 private:
-	AutoSeededFortuna<CIPHER, RESEED_HASH, POOL_HASH>* GetSingleton() {return &Singleton<AutoSeededFortuna<CIPHER,RESEED_HASH,POOL_HASH>>().Ref();}
+	AutoSeededFortuna<CIPHER, RESEED_HASH, POOL_HASH>* GetSingleton() {return &Singleton<AutoSeededFortuna<CIPHER,RESEED_HASH,POOL_HASH> >().Ref();}
 };
 
 // use this typedef if you can't guarantee consistent template-parameters for AutoSeededFortunaSingleton

--- a/Source/CryptoPP/dhash.h
+++ b/Source/CryptoPP/dhash.h
@@ -1,0 +1,32 @@
+#ifndef CRYPTOPP_DHASH_H
+#define CRYPTOPP_DHASH_H
+
+
+NAMESPACE_BEGIN(CryptoPP)
+
+template<class BASE>
+class CRYPTOPP_DLL DoubledHash: public BASE
+{
+public:
+	static const char * CRYPTOPP_API StaticAlgorithmName() { return BASE::StaticAlgorithmName(); }
+
+	void TruncatedFinal(byte *digest, size_t digestSize)
+  {
+    unsigned char firstDigest[BASE::DIGESTSIZE] = {0};
+    m_hash.Final(firstDigest);
+    m_hash.Restart();
+    m_hash.Update(firstDigest, BASE::DIGESTSIZE);
+    m_hash.TruncatedFinal(digest, digestSize);
+  }
+
+	unsigned int DigestSize() const { return BASE::DIGESTSIZE; }
+	void Update(const byte *input, size_t length) { m_hash.Update(input, length); }
+
+private:
+	BASE m_hash;
+};
+
+
+NAMESPACE_END
+
+#endif // CRYPTOPP_DHASH_H


### PR DESCRIPTION
I tried to make Fortuna implementation strictly follow original design.

I've cross-checked this code with Fortuna from pycrypto. The code produces results same as pycrypto if you'll std::reverse m_Counter before feeding into AES-CTR and std::reverse back afterwards. Pycrypto uses little-endian counter in AES-CTR: https://github.com/dlitz/pycrypto/blob/master/lib/Crypto/Random/Fortuna/FortunaGenerator.py#L66
